### PR TITLE
Temporary solution to unblock GitHub integration

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,8 +1,3 @@
-languages_mapping:
-  two_letters_code:
-    zh-CN: zh-CN
-    zh-TW: zh-TW
-preserve_hierarchy: 1
 files:
   - source: /docs/**/*
     ignore:
@@ -10,3 +5,6 @@ files:
       - gas-in-sui.mdx
       - sui-json-format.mdx
     translation: /i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
+    languages_mapping:
+      two_letters_code:
+        es-ES: ESP

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,4 +8,5 @@ files:
     ignore:
       - install-sui.mdx
       - gas-in-sui.mdx
+      - sui-json-format.mdx
     translation: /i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -5,4 +5,6 @@ languages_mapping:
 preserve_hierarchy: 1
 files:
   - source: /docs/**/*
+    ignore:
+      - install-sui.mdx
     translation: /i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -7,4 +7,5 @@ files:
   - source: /docs/**/*
     ignore:
       - install-sui.mdx
+      - gas-in-sui.mdx
     translation: /i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -7,4 +7,5 @@ files:
     translation: /i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
     languages_mapping:
       two_letters_code:
-        es-ES: ESP
+        zh-CN: zh-CN
+        zh-TW: zh-TW


### PR DESCRIPTION
There are 3 files that cannot be processed at the moment (we're looking into it) and it has impact on the integration. Please merge current changes to the configuration file and then resume integration in Crowdin to sync files. Once we improve files handling, ignored items will be removed from the configuration.

In addition, `preserve_hierarchy` was removed because value `1` is used by default for GitHub sync + languages mapping is specified as expected