### PR TITLE
Added component and example use

### DIFF
--- a/docs/examples/hot-potato.mdx
+++ b/docs/examples/hot-potato.mdx
@@ -3,6 +3,8 @@ title: Hot Potato
 slug: /hot-potato
 ---
 
+import ExampleImport from '@site/src/components/ExampleImport';
+
 A Hot Potato is the name of a struct that has no abilities, hence it can only be packed and unpacked in its module. In this struct, you must call function B after function A in the case where function A returns a potato and function B consumes it.
 
 ```sui-move
@@ -70,6 +72,6 @@ module examples::trade_in {
 }
 ```
 
-This pattern is used in these examples:
+The Sui repository includes [several examples](https://github.com/MystenLabs/sui/tree/main/sui_programmability/examples) that demonstrate Sui capabilities. The following [Flash Loan](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/defi/sources/flash_lender.move) code from the set of examples demonstrates the pattern this topic describes: 
 
-- [Flash Loan](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/defi/sources/flash_lender.move)
+<ExampleImport file="/sui_programmability/examples/defi/sources/flash_lender.move" type="move" />

--- a/src/components/ExampleImport/index.tsx
+++ b/src/components/ExampleImport/index.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect } from "react";
+import Highlight from "prism-react-renderer";
+import github from 'prism-react-renderer/themes/github';
+import axios from "axios";
+import { Prism } from "prism-react-renderer";
+import CopyButton from "@theme/CodeBlock/CopyButton";
+import { Language } from "prism-react-renderer";
+require("prismjs/components/prism-rust");
+
+import styles from "./styles.module.css";
+
+type LangExt = Language | "rust";
+
+const BASE = "https://raw.githubusercontent.com/MystenLabs/sui/main";
+
+export default function ExampleImport(props) {
+    const [example, setExample] = useState(null);
+    const {file, type, lineStart, lineEnd, showLineNumbers, appendToCode, prependToCode} = props;
+    const fileUrl = BASE + file;
+    const prefix = file
+                    .replaceAll('/', '_')
+                    .replaceAll('.', '_')
+                    .toLowerCase();
+    const subStart = lineStart - 1 || 0;
+    const subEnd = lineEnd || 0;
+
+    let highlight:LangExt = 'tsx'; //default
+    
+    if (type == 'move'){
+        highlight = 'rust'; //move is not an option
+    } else if ( typeof(type) != "undefined" ) {
+        highlight = type;
+    }
+    
+    useEffect(() => {
+        axios
+            .get(fileUrl)
+            .then((response) => {
+                if (subStart > 0 || subEnd > 0){
+                    let appends = [];
+                    let lines = response.data.split("\n");
+                    if (subStart > 0 && subEnd > 0){
+                        lines.splice(0, subStart);
+                        lines.splice(subEnd - subStart, lines.length);
+                    } else if (subStart > 0){
+                        lines.splice(0, subStart);
+                    } else if (subEnd > 0){
+                        lines.splice(subEnd, lines.length);
+                    }
+                    if (appendToCode){
+                        appends = appendToCode.split("\n");
+                        lines = [...lines, ...appends];
+                    }
+                    if (prependToCode){
+                        appends = prependToCode.split("\n");
+                        lines = [...appends, ...lines];
+                    }
+                    setExample(lines.join('\n'));
+                } else {
+                    setExample(response.data);
+                }   
+            })
+            .catch(error => {
+                setExample("Error loading file.");
+                console.log(error);
+            });
+    }, []);    
+      
+    if (!example) return null;
+      
+    return (
+        <Highlight Prism={Prism} code={example} language={highlight as Language} theme={github}>
+            {({ className, style, tokens, getLineProps, getTokenProps }) => (
+                <div className="codeBlockContainer_node_modules-@docusaurus-theme-classic-lib-theme-CodeBlock-Container-styles-module theme-code-block">
+                    <div className="codeBlockContent_node_modules-@docusaurus-theme-classic-lib-theme-CodeBlock-Content-styles-module">
+                        <pre> 
+                            {tokens.map((line, i) => (
+                                <div key={'div_' + prefix + i} {...getLineProps({ line })}>
+                                    {showLineNumbers && <span className={styles.lineNumbers}>{i + 1}{"\t"}</span>}
+                                    {line.map((token, key) => (
+                                        <span key={prefix + key} {...getTokenProps({ token })} />
+                                    ))}
+                                </div>
+                            ))}    
+                        </pre>
+                        <div className="buttonGroup_node_modules-@docusaurus-theme-classic-lib-theme-CodeBlock-Content-styles-module">
+                            <CopyButton code={example}/>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </Highlight>
+    );
+}

--- a/src/components/ExampleImport/index.tsx
+++ b/src/components/ExampleImport/index.tsx
@@ -17,6 +17,7 @@ export default function ExampleImport(props) {
     const [example, setExample] = useState(null);
     const {file, type, lineStart, lineEnd, showLineNumbers, appendToCode, prependToCode} = props;
     const fileUrl = BASE + file;
+    const fileExt = file.split('.').pop();
     const prefix = file
                     .replaceAll('/', '_')
                     .replaceAll('.', '_')
@@ -24,9 +25,9 @@ export default function ExampleImport(props) {
     const subStart = lineStart - 1 || 0;
     const subEnd = lineEnd || 0;
 
-    let highlight:LangExt = 'tsx'; //default
+    let highlight:LangExt = fileExt; //default
     
-    if (type == 'move'){
+    if (type == 'move' || highlight == 'move' as LangExt){
         highlight = 'rust'; //move is not an option
     } else if ( typeof(type) != "undefined" ) {
         highlight = type;

--- a/src/components/ExampleImport/styles.module.css
+++ b/src/components/ExampleImport/styles.module.css
@@ -1,0 +1,13 @@
+.lineNumbers {
+    color: #aaa;
+    font-size: 10px;
+    vertical-align: middle;
+}
+
+.token-line span:first-child {
+    margin-left: 1rem;
+}
+
+.token-line .highlighted {
+    background-color: #fff000;
+}


### PR DESCRIPTION
Proposed component to include code samples from the Sui repo in MDX files. Using this component would enable a single source of truth for code content and allow integration of testing to ensure viable code is always provided. Content creators would be able to include an entire file or a portion of the code. 

A simple example is included that displays the entire file referenced. Although simplistic, the example shows how we can provide tested code to the user in the docs site without them having to navigate to github (but still have that option).