### PR TITLE
Update devInspect documentation

### DIFF
--- a/docs/reference/json-rpc/governance-read-api.mdx
+++ b/docs/reference/json-rpc/governance-read-api.mdx
@@ -16,7 +16,7 @@ Return the committee information for the asked `epoch`.
 
 #### Result
 
-##### `<DevInspectResults>`
+##### `<SuiCommittee>` : `<CommitteeInfo>`
 
 | Name | Required | Format | Description
 |---|---|---|---|

--- a/docs/reference/json-rpc/move-utils-api.mdx
+++ b/docs/reference/json-rpc/move-utils-api.mdx
@@ -18,7 +18,7 @@ Return the argument types of a Move function, based on normalized Type.
 
 #### Result
 
-##### `<DevInspectResults>`
+##### `Vec<MoveFunctionArgType>` : `<[MoveFunctionArgType]>`
 
 | Name | Required | Format | Description
 |---|---|---|---|

--- a/docs/reference/json-rpc/write-api.mdx
+++ b/docs/reference/json-rpc/write-api.mdx
@@ -6,7 +6,7 @@ slug: /write-api
 
 ### `sui_devInspectTransactionBlock`
 
-Runs the transaction in dev-inspect mode. Which allows for nearly any transaction (or Move call) with any arguments. Detailed results are provided, including both the transaction effects and any return values.
+Simulates running the transaction, even one that would be normally impossible, against the current state of the network. Nearly any transaction (or Move call) with any arguments can run in dev-inspect; transaction inputs are not checked, entry function verification is skipped, values can be left unused, and returns are not validated. Detailed results are provided, including both the transaction effects and any return values. Dev-inspect is provided to aid in understanding the effects of any possible action against the current network state. See dryRunTransactionBlock for a more faithful simulation of what would happen if the transaction were actually run.
 
 #### Parameters
 
@@ -29,8 +29,6 @@ Runs the transaction in dev-inspect mode. Which allows for nearly any transactio
 | `results` | False | `<[SuiExecutionResult]>` | Execution results (including return values) from executing the transactions |
 
 #### Example
-
-Runs the transaction in dev-inspect mode. Which allows for nearly any transaction (or Move call) with any arguments. Detailed results are provided, including both the transaction effects and any return values.
 
 ```mdx-code-block
 <details>


### PR DESCRIPTION
This PR removes some spurious DevInspectResults instances and adds better documentation for the DevInspect RPC.